### PR TITLE
fix func.invoke

### DIFF
--- a/src/js/base/core/func.js
+++ b/src/js/base/core/func.js
@@ -48,7 +48,7 @@ function self(a) {
 
 function invoke(obj, method) {
   return () => {
-    return obj[method].apply(obj, arguments);
+    return obj[method].call(obj);
   };
 }
 


### PR DESCRIPTION
func.invoke is needed for directly adding justifyLeft to the toolbar
